### PR TITLE
Bugfix: Do not crash EnumAudioDevices if no default audio endpoint is set

### DIFF
--- a/windows/win32audio_plugin.cpp
+++ b/windows/win32audio_plugin.cpp
@@ -124,13 +124,15 @@ std::vector<DeviceProps> EnumAudioDevices(EDataFlow deviceType, ERole eRole)
         if (SUCCEEDED(hr))
         {
             IMMDevice *pActive = NULL;
+            wstring activeDevID;
 
-            pEnumerator->GetDefaultAudioEndpoint(deviceType, eRole, &pActive);
-            LPWSTR activeID;
-            pActive->GetId(&activeID);
-            wstring activeDevID(activeID);
-
-            pActive->Release();
+            hr = pEnumerator->GetDefaultAudioEndpoint(deviceType, eRole, &pActive);
+            if (SUCCEEDED(hr) && pActive != NULL) {
+                LPWSTR activeID;
+                pActive->GetId(&activeID);
+                activeDevID = activeID;
+                pActive->Release();
+            }
 
             IMMDeviceCollection *pCollection = NULL;
             hr = pEnumerator->EnumAudioEndpoints(deviceType, DEVICE_STATE_ACTIVE, &pCollection);


### PR DESCRIPTION
This PR gracefully handles an edge case when no default audio endpoint is set, i.e. if the system has no input audio device.

For testing I'd recommend to disable all audio input devices through the Windows device manager.